### PR TITLE
Explicitly use a default python version; other minor changes.

### DIFF
--- a/rambo/__main__.py
+++ b/rambo/__main__.py
@@ -103,7 +103,12 @@ def main(argv=None):
 
     recipes_dir = os.path.normpath(args.recipes_dir)
 
-    versions = {'python': '', 'numpy': ''}
+    # If --python not specified, use version of current interpreter.
+    vinfo = sys.version_info
+    default_pyver = '{}.{}'.format(
+            vinfo.major,
+            vinfo.minor)
+    versions = {'python': default_pyver, 'numpy': ''}
     if args.python:
         versions['python'] = args.python
 


### PR DESCRIPTION
Also:
* Remove redundant manifest filtering method.
* Wording changes